### PR TITLE
Chart 0.0.10 [DBCall 2.1.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 0.0.10 [DBCall 2.1.0] - 2023-12-19
+### Helm changes
+- New application version
+- Fixed an issue with a blocking Mutex that was preventing connections to different databases.
+- Updated dependencies.
+- Alpine version bumped to 1.19.
+
 ## Chart 0.0.9 [DBCall 2.0.1] - 2023-11-14
 ### Helm changes
 - New application version

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dbcall
-version: 0.0.9
+version: 0.0.10
 description: Chart for DBCall
 type: application
 keywords:
@@ -8,7 +8,7 @@ keywords:
 home: https://simulator.company/
 dependencies:
   - name: dbcall
-    version: 0.0.9
+    version: 0.0.10
 
 maintainers:
   - name: Andrey Vinokourov
@@ -16,4 +16,4 @@ maintainers:
 
 icon: https://corezoid.com/static/CorezoidProduct-c2321aa03a80b8ff37d11a82a080ae83.png
 
-appVersion: 2.0.1
+appVersion: 2.1.0

--- a/charts/dbcall/Chart.yaml
+++ b/charts/dbcall/Chart.yaml
@@ -3,5 +3,5 @@ name: dbcall
 description: Chart for DBCall.
 icon: https://corezoid.com/static/CorezoidProduct-c2321aa03a80b8ff37d11a82a080ae83.png
 type: application
-version: 0.0.9
-appVersion: 2.0.1
+version: 0.0.10
+appVersion: 2.1.0


### PR DESCRIPTION
## Chart 0.0.10 [DBCall 2.1.0] - 2023-12-19
### Helm changes
- New application version
- Fixed an issue with a blocking Mutex that was preventing connections to different databases.
- Updated dependencies.
- Alpine version bumped to 1.19.