### PR TITLE
Update DBCall Helm chart to version 0.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 0.0.20 [DBCall 2.5.0] - 2026-04-07
+### Application Versions
+- **dbcall**: 2.5.0
+### Helm changes
+- Updated DBCall image to version 2.5.0
+
 ## Chart 0.0.19 [DBCall 2.4.0] - 2025-12-05
 ### Application Versions
 - **dbcall**: 2.4.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dbcall
-version: 0.0.19
+version: 0.0.20
 description: Chart for DBCall
 type: application
 keywords:
@@ -8,7 +8,7 @@ keywords:
 home: https://simulator.company/
 dependencies:
   - name: dbcall
-    version: 0.0.19
+    version: 0.0.20
 
 maintainers:
   - name: Andrey Vinokourov
@@ -16,4 +16,4 @@ maintainers:
 
 icon: https://corezoid.com/static/CorezoidProduct-c2321aa03a80b8ff37d11a82a080ae83.png
 
-appVersion: 2.3.0
+appVersion: 2.5.0

--- a/charts/dbcall/Chart.yaml
+++ b/charts/dbcall/Chart.yaml
@@ -3,5 +3,5 @@ name: dbcall
 description: Chart for DBCall.
 icon: https://corezoid.com/static/CorezoidProduct-c2321aa03a80b8ff37d11a82a080ae83.png
 type: application
-version: 0.0.19
-appVersion: 2.4.0
+version: 0.0.20
+appVersion: 2.5.0


### PR DESCRIPTION
- Updated root chart version from 0.0.19 to 0.0.20
- Updated appVersion from 2.3.0 to 2.5.0
- Updated dbcall subchart version from 0.0.19 to 0.0.20 (appVersion 2.5.0)
- Updated CHANGELOG.md with new release entry