### PR TITLE
Release new Helm chart version 0.0.21

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -20,3 +20,12 @@
 .idea/
 *.tmproj
 .vscode/
+
+# AI agent files
+CLAUDE.md
+AGENTS.md
+.claude/
+
+# Documentation and task files
+docs/
+task.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 0.0.21 [DBCall 2.5.0] - 2026-04-09
+### Helm changes
+- Added `secretName` field to `global.mq.secret` for external secrets support (Vault, External Secrets Operator, Sealed Secrets)
+- When `create: false`, the chart no longer requires `data` section — Secret is expected to be managed externally
+- `secretName` overrides the computed Secret name (`{{ .Release.Name }}-dbcall-{{ name }}`)
+- Skip Secret creation when `secretName` is set (even if `create: true`)
+- Excluded dev/AI files from Helm chart build pipeline (CLAUDE.md, AGENTS.md, .claude/, .idea/, docs/, task.md)
+
 ## Chart 0.0.20 [DBCall 2.5.0] - 2026-04-07
 ### Application Versions
 - **dbcall**: 2.5.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dbcall
-version: 0.0.20
+version: 0.0.21
 description: Chart for DBCall
 type: application
 keywords:
@@ -8,7 +8,7 @@ keywords:
 home: https://simulator.company/
 dependencies:
   - name: dbcall
-    version: 0.0.20
+    version: 0.0.21
 
 maintainers:
   - name: Andrey Vinokourov

--- a/charts/dbcall/Chart.yaml
+++ b/charts/dbcall/Chart.yaml
@@ -3,5 +3,5 @@ name: dbcall
 description: Chart for DBCall.
 icon: https://corezoid.com/static/CorezoidProduct-c2321aa03a80b8ff37d11a82a080ae83.png
 type: application
-version: 0.0.20
+version: 0.0.21
 appVersion: 2.5.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,7 +37,11 @@ simulator.observability/scrape: "true"
 {{- end -}}
 
 {{- define "dbcall.rabbitSecretName" -}}
+{{- if .Values.global.mq.secret.secretName -}}
+{{ .Values.global.mq.secret.secretName }}
+{{- else -}}
 {{ .Release.Name }}-dbcall-{{ .Values.global.mq.secret.name }}
+{{- end -}}
 {{- end -}}
 
 {{- define "common.initWait.image" -}}

--- a/templates/rabbitmq-secret.yaml
+++ b/templates/rabbitmq-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.mq.secret.create }}
+{{- if and .Values.global.mq.secret.create (not .Values.global.mq.secret.secretName) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/values.yaml
+++ b/values.yaml
@@ -18,10 +18,17 @@ global:
     internal: true
     ## secret configuration for rabbitmq
     secret:
-      ## true - secret will be created automatically with provided values
-      ## false - secret should be created manually
+      ## create: true  — Helm creates the Secret from "data" below
+      ## create: false — Secret is managed externally (Vault, External Secrets Operator, etc.);
+      ##                  "data" section is not required.
+      ##                  External Secret must contain keys: host, port, vhost, username, password
       create: true
+      ## name — used to compute Secret name: {{ .Release.Name }}-dbcall-{{ name }}
       name: "rabbitmq-secret"
+      ## secretName — override the full Secret name (ignores "name" above).
+      ## Use when the external Secret has a name that doesn't follow the chart's naming convention.
+      # secretName: "my-external-rabbitmq-secret"
+      ## data is only used when create: true
       data:
         # host: "rabbitmq.rabbitmq.svc.cluster.local"
         host: "RABBTMQ_HOST"  # If internal: true, then this host


### PR DESCRIPTION
## Chart 0.0.21 [DBCall 2.5.0] - 2026-04-09
### Helm changes
- Added `secretName` field to `global.mq.secret` for external secrets support (Vault, External Secrets Operator, Sealed Secrets)
- When `create: false`, the chart no longer requires `data` section — Secret is expected to be managed externally
- `secretName` overrides the computed Secret name (`{{ .Release.Name }}-dbcall-{{ name }}`)
- Skip Secret creation when `secretName` is set (even if `create: true`)
- Excluded dev/AI files from Helm chart build pipeline (CLAUDE.md, AGENTS.md, .claude/, .idea/, docs/, task.md)